### PR TITLE
Added the Halo Material Tools Panel

### DIFF
--- a/io_scene_halo/misc/__init__.py
+++ b/io_scene_halo/misc/__init__.py
@@ -72,6 +72,96 @@ class JMA_BatchDialog(Operator):
         context.window_manager.fileselect_add(self)
         return {'RUNNING_MODAL'}
 
+class H3EK_PathDialog(Operator):
+    """Set H3EK"""
+    bl_idname = "import_scene.h3ek_path"
+    bl_label = "Set H3EK Directory"
+
+    filter_glob: StringProperty(
+        default="*.exe",
+        options={'HIDDEN'},
+        )
+
+    directory: StringProperty(
+        name="Directory",
+        description="The H3EK Directory",
+    )
+
+    def execute(self, context):
+        scene = context.scene
+        scene_halo_h3ek_path = scene.halo_h3ek_path
+        scene_halo_h3ek_path.directory = self.directory
+        context.area.tag_redraw()
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        context.window_manager.fileselect_add(self)
+        return {'RUNNING_MODAL'}
+
+class H3EK_DataPathDialog(Operator):
+    """Set H3EK"""
+    bl_idname = "import_scene.h3ek_data_path"
+    bl_label = "Set H3EK Data Directory"
+
+    filter_glob: StringProperty(
+        default="*.exe",
+        options={'HIDDEN'},
+        )
+
+    directory: StringProperty(
+        name="Directory",
+        description="The H3EK Data Directory",
+    )
+
+    def execute(self, context):
+        scene = context.scene
+        scene_halo_h3ek_data_path = scene.halo_h3ek_data_path
+        scene_halo_h3ek_data_path.directory = self.directory
+        context.area.tag_redraw()
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        context.window_manager.fileselect_add(self)
+        return {'RUNNING_MODAL'}
+
+class Halo_MaterialPropertiesGroup(PropertyGroup):
+    set_mattype: BoolProperty(
+        name ="Set Material Type",
+        description = "Sets the material type of the materials in the selected object",
+        default = False,
+    )
+
+    mat_types: EnumProperty(
+        name="Material Types:",
+        description="What material type to use for the materials in the object",
+        items=[ ('two_sided', "Two Sided", "Two Sided"),
+                ('render_only', "Render Only", "Render Only"),
+                ('collision_only', "Collision Only", "Collision Only"),
+                ('sphere_collision_only', "Large Collideable", "Large Collideable"),
+                ('transparent_1_sided', "One-Sided Transparent", "One-Sided Transparent"),
+                ('transparent_2_sided', "Two-Sided Transparent", "Two-Sided Transparent"),
+                ('slip_surface', "Slip Surface", "Slip Surface"),
+                ('group_transparents_by_plane', "Group Transparents by Plane", "Group Transparents by Plane"),
+                ('fog_plane', "Fog Plane", "Fog Plane"),
+                ('water_surface', "Water Surface", "Water Surface"),
+                ('breakable', "Breakable", "Breakable"),
+                ('conveyor', "Conveyor", "Conveyor"),
+                ('ladder', "Ladder", "Ladder"),
+                ('decal_offset', "Decal Offset", "Decal Offset"),
+                ('ai_deafening', "AI Deafening", "AI Deafening"),
+                ('blocks_sound', "Blocks Sound", "Blocks Sound"),
+                ('no_shadow', "No Shadow", "No Shadow"),
+                ('shadow_only', "Shadow Only", "Shadow Only"),
+                ('lightmap_only', "Lightmap Only", "Lightmap Only"),
+                ('ignored_by_lightmaps', "Ignored by Lightmaps", "Ignored by Lightmaps"),
+                ('precise', "Precise", "Precise"),
+                ('portal_exact', "Portal Exact", "Portal Exact"),
+                ('portal_1_way', "One Way Portal", "One Way Portal"),
+                ('portal_door', "Portal Door", "Portal Door"),
+                ('portal_vis_blocker', "Portal Visibility Blocker", "Portal Visibility Blocker"),
+               ]
+        )
+
 class JMA_BatchPropertiesGroup(PropertyGroup):
     jma_version: EnumProperty(
         name="Version:",
@@ -135,6 +225,16 @@ class JMA_BatchPropertiesGroup(PropertyGroup):
     directory: StringProperty(
         name="Directory",
         description="A directory containing animation source files to convert",
+        )
+
+class Halo_H3EKPropertiesGroup(PropertyGroup):
+    directory: StringProperty(
+        name="Directory",
+        description="The H3EK Directory",
+        )
+    datadirectory: StringProperty(
+        name="Data Directory",
+        description="The H3EK Data Directory",
         )
 
 class Halo_ImportFixupPropertiesGroup(PropertyGroup):
@@ -837,6 +937,42 @@ class Halo_BatchAnimConverter(Panel):
         row = col.row()
         row.operator("halo_bulk.anim_convert", text="Convert Directory")
 
+class Halo_MatTools(Panel):
+    bl_label = "Halo Material Tools"
+    bl_idname = "HALO_PT_MatTools"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_options = {'DEFAULT_CLOSED'}
+    bl_parent_id = "HALO_PT_AutoTools"
+
+    def draw(self, context):
+        from ..misc import mattools
+        layout = self.layout
+        scene = context.scene
+        scene_halo = scene.halo
+        scene_halo_h3ek_path = scene.halo_h3ek_path
+        scene_halo_h3ek_data_path = scene.halo_h3ek_data_path
+        scene_halo_mattype = scene.halo_mattype
+        col = layout.column(align=True)
+        row = col.row()
+        row.operator(H3EK_PathDialog.bl_idname, text="Select H3EK Directory")
+        row.prop(scene_halo_h3ek_path, "directory", text='')
+        row = col.row()
+        row.operator(H3EK_DataPathDialog.bl_idname, text="Select Data Directory")
+        row.prop(scene_halo_h3ek_data_path, "directory", text='')
+        row = col.row()
+        row.operator(Export_Textures.bl_idname, text="Export Textures")
+        row = col.row()
+        row.operator(Make_Bitmaps.bl_idname, text="Make Bitmaps")
+        row = col.row()
+        row.label(text='Set Material Type')
+        row.prop(scene_halo_mattype, "mat_types", text='')
+        row = col.row()
+        row.operator(Set_Material_Type.bl_idname, text='Apply Material Type')
+        row = col.row()
+        row.operator(Enable_Material_Type.bl_idname, text='Toggle Usage of Material Types')
+
+
 class Halo_Sky_Tools_Helper(Panel):
     """Tools to help automate Halo workflow"""
     bl_label = "Halo Sky Tools Helper"
@@ -1215,14 +1351,67 @@ class Bulk_Anim_Convert(Operator):
     def execute(self, context):
         from ..misc import batch_anims
         scene_halo_anim_batch = context.scene.halo_anim_batch
-
+        
         return global_functions.run_code("batch_anims.write_file(context, self.report, scene_halo_anim_batch.directory, scene_halo_anim_batch.jma_version, scene_halo_anim_batch.jma_version_ce, scene_halo_anim_batch.jma_version_h2, scene_halo_anim_batch.jma_version_h3, scene_halo_anim_batch.game_version)")
 
 def menu_func_export(self, context):
     self.layout.operator(ExportLightmap.bl_idname, text="Halo Lightmap UV (.luv)")
 
+class Export_Textures(Operator):
+    """Exports Textures for the selected object"""
+    bl_idname = 'halo_mattools.export_texture'
+    bl_label = 'Export Textures'
+    bl_options = {"REGISTER", "UNDO"}
+    
+    def execute(self, context):
+        from ..misc import mattools
+        scene = context.scene
+        scene_halo_h3ek_data_path = scene.halo_h3ek_data_path
+
+        return global_functions.run_code("mattools.export_texture(context, scene_halo_h3ek_data_path.directory)")
+
+class Make_Bitmaps(Operator):
+    """Make Bitmaps out of Tifs in Working Data Directory"""
+    bl_idname = 'halo_mattools.make_bitmaps'
+    bl_label = 'Make Bitmaps'
+    bl_options = {"REGISTER", "UNDO"}
+    
+    def execute(self, context):
+        from ..misc import mattools
+        scene = context.scene
+        scene_halo_h3ek_data_path = scene.halo_h3ek_data_path
+        scene_halo_h3ek_path = context.scene.halo_h3ek_path
+
+        return global_functions.run_code("mattools.make_bitmaps(context, scene_halo_h3ek_path.directory, scene_halo_h3ek_data_path.directory)")
+
+class Set_Material_Type(Operator):
+    """Set Material Type"""
+    bl_idname = 'halo_mattools.set_material_type'
+    bl_label = 'Set Material Type'
+    bl_options = {"REGISTER", "UNDO"}
+    
+    def execute(self, context):
+        from ..misc import mattools
+        scene = context.scene
+        scene_halo_mattype = scene.halo_mattype
+        return global_functions.run_code("mattools.set_material_type(context, scene_halo_mattype.mat_types)")
+
+class Enable_Material_Type(Operator):
+    """Enables/Disables the usage of material types"""
+    bl_idname = 'halo_mattools.enable_material_type'
+    bl_label = 'Set Material Type'
+    bl_options = {"REGISTER", "UNDO"}
+    
+    def execute(self, context):
+        from ..misc import mattools
+        scene = context.scene
+        scene_halo_mattype = scene.halo_mattype
+        return global_functions.run_code("mattools.enable_material_type(context)")
 classeshalo = (
+    Halo_MaterialPropertiesGroup,
     JMA_BatchDialog,
+    H3EK_PathDialog,
+    H3EK_DataPathDialog,
     ExportLightmap,
     Bulk_Lightmap_Images,
     Bulk_Rename_Bones,
@@ -1249,6 +1438,11 @@ classeshalo = (
     Halo_IKHelper,
     Halo_MultiUserHelper,
     Halo_BatchAnimConverter,
+    Halo_MatTools,
+    Export_Textures,
+    Make_Bitmaps,
+    Set_Material_Type,
+    Enable_Material_Type,
     Halo_Sky_Tools_Helper,
     Halo_Sky_Dome,
     Halo_Sky_Light,
@@ -1258,6 +1452,7 @@ classeshalo = (
     Halo_Sky_Sun_Color,
     Halo_Sky_Misc_Settings,
     JMA_BatchPropertiesGroup,
+    Halo_H3EKPropertiesGroup,
     Halo_ImportFixupPropertiesGroup,
     Halo_LightmapperPropertiesGroup,
     Scale_ModelPropertiesGroup,
@@ -1278,7 +1473,9 @@ def register():
     bpy.types.Scene.halo_sky = PointerProperty(type=SkyPropertiesGroup, name="Sky Helper", description="Generate a sky for Halo 3")
     bpy.types.Scene.halo_face_set = PointerProperty(type=Face_SetPropertiesGroup, name="Halo Face Set Helper", description="Creates a facemap with the exact name we need")
     bpy.types.Scene.halo_anim_batch = PointerProperty(type=JMA_BatchPropertiesGroup, name="Halo Batch Anims", description="Converts all animations in a specific directory to a different version.")
-
+    bpy.types.Scene.halo_h3ek_path = PointerProperty(type=Halo_H3EKPropertiesGroup, name="H3EK Path", description="The H3EK Path")
+    bpy.types.Scene.halo_h3ek_data_path = PointerProperty(type=Halo_H3EKPropertiesGroup, name="H3EK Path", description="The H3EK Data Path")
+    bpy.types.Scene.halo_mattype = PointerProperty(type=Halo_MaterialPropertiesGroup, name ="Material Properties", description="Set the material properties of the active object")
 def unregister():
     bpy.types.TOPBAR_MT_file_export.remove(menu_func_export)
     del bpy.types.Scene.halo_import_fixup
@@ -1288,6 +1485,9 @@ def unregister():
     del bpy.types.Scene.halo_sky
     del bpy.types.Scene.halo_face_set
     del bpy.types.Scene.halo_anim_batch
+    del bpy.types.Scene.halo_h3ek_path
+    del bpy.types.Scene.halo_h3ek_data_path
+    del bpy.types.Scene.halo_mattype
     for clshalo in classeshalo:
         bpy.utils.unregister_class(clshalo)
 

--- a/io_scene_halo/misc/mattools.py
+++ b/io_scene_halo/misc/mattools.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# Copyright (c) 2021 Steven Garcia
+# Copyright (c) 2021 SamDamDing AKA MercyMoon
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/io_scene_halo/misc/mattools.py
+++ b/io_scene_halo/misc/mattools.py
@@ -1,0 +1,80 @@
+# ##### BEGIN MIT LICENSE BLOCK #####
+#
+# MIT License
+#
+# Copyright (c) 2021 Steven Garcia
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# ##### END MIT LICENSE BLOCK #####
+
+import subprocess
+import bpy
+from ..global_functions import mesh_processing
+
+def export_texture(context, directory):
+    scene = context.scene
+    for obj in bpy.context.scene.objects:
+        for slot in obj.material_slots:
+            if slot.material and slot.material.use_nodes:
+                for node in slot.material.node_tree.nodes:
+                    if node.type == 'TEX_IMAGE':
+                        imagename=node.image.name
+                        imagename = imagename.rpartition('.')
+                        imagename = imagename[0]
+                        node.image.filepath_raw = directory + imagename + ".tif"
+                        print("Exporting " + node.image.name + " to " + node.image.filepath_raw)
+                        node.image.file_format = "TIFF"
+                        node.image.save()
+    return {"FINISHED"}
+
+def make_bitmaps(context, toolpath, directory):
+    scene = context.scene
+    H3EK = toolpath
+    Tool = H3EK + r'\tool.exe'
+    BitmapPath = directory
+    BitmapPath = str(BitmapPath.split(H3EK)[1])
+    BitmapPath = str(BitmapPath.split("data\\")[1])
+    print("Making Bitmaps out of Tifs in " + directory)
+    result = subprocess.Popen([Tool, "bitmaps", BitmapPath], cwd=H3EK)
+    print("stdout:", result.stdout)
+    return {'FINISHED'}
+
+def enable_material_type(context):
+    active_object = context.view_layer.objects.active
+    if active_object.type== 'MESH':
+        for material in active_object.data.materials:
+            if getattr(material.ass_jms, 'is_bm') == False:
+                setattr(material.ass_jms, 'is_bm', True)
+            else:
+                setattr(material.ass_jms, 'is_bm', False)
+    return {"FINISHED"}
+
+def set_material_type(context, material_type):
+    active_object = context.view_layer.objects.active
+    if active_object.type== 'MESH':
+        for material in active_object.data.materials:
+            if getattr(material.ass_jms, material_type) == False:
+                setattr(material.ass_jms, material_type, True)
+            else:
+                setattr(material.ass_jms, material_type, False)
+    return {"FINISHED"}
+
+if __name__ == '__main__':
+    bpy.ops.halo_mattools.export_texture()


### PR DESCRIPTION
Added a Halo Material Tools Panel because I like to apply material properties on a per object basis.  More practical too.
You can also export the textures of all the materials in the scene to the data directory and then turn them into bitmaps if you set the proper directories.

![blender_pOXGnhNElk](https://user-images.githubusercontent.com/45549722/158054455-9a59a500-28da-4ceb-85b3-28947f08161d.png)
