### PR TITLE
Option to ignore top level collections that are excluded for ASS exports

### DIFF
--- a/io_scene_halo/file_ass/__init__.py
+++ b/io_scene_halo/file_ass/__init__.py
@@ -334,7 +334,7 @@ class ExportASS(Operator, ExportHelper):
         default = True,
         )
 
-        exluded_collections: BoolProperty(
+    exluded_collections: BoolProperty(
         name ="Export excluded top level collections",
         description = "Whether or not we ignore collections that are excluded from the view layer",
         default = True,

--- a/io_scene_halo/file_ass/__init__.py
+++ b/io_scene_halo/file_ass/__init__.py
@@ -106,7 +106,7 @@ class ASS_ScenePropertiesGroup(PropertyGroup):
         description = "Whether or not we ignore geometry that has scene options that hides it from the viewport",
         default = True,
         )
-
+        
     exluded_collections: BoolProperty(
         name ="Export top level excluded collections",
         description = "Whether or not we ignore collections that are excluded from the view layer",
@@ -475,7 +475,7 @@ class ExportASS(Operator, ExportHelper):
             self.scale_float = args.scale_float
             self.console = args.console
 
-        return global_functions.run_code("export_ass.write_file(context, self.filepath, self.ass_version, self.ass_version_h2, self.ass_version_h3, self.game_version, self.folder_structure, self.hidden_geo, exluded_collections, self.apply_modifiers, self.triangulate_faces, self.edge_split, self.use_edge_angle, self.use_edge_sharp, self.split_angle, self.clean_normalize_weights, self.scale_enum, self.scale_float, self.console, self.report)")
+        return global_functions.run_code("export_ass.write_file(context, self.filepath, self.ass_version, self.ass_version_h2, self.ass_version_h3, self.game_version, self.folder_structure, self.hidden_geo, self.exluded_collections, self.apply_modifiers, self.triangulate_faces, self.edge_split, self.use_edge_angle, self.use_edge_sharp, self.split_angle, self.clean_normalize_weights, self.scale_enum, self.scale_float, self.console, self.report)")
 
     def draw(self, context):
         scene = context.scene
@@ -492,11 +492,7 @@ class ExportASS(Operator, ExportHelper):
             self.ass_version_h2 = scene_ass.ass_version_h2
             self.ass_version_h3 = scene_ass.ass_version_h3
             self.folder_structure = scene_ass.folder_structure
-      
-        row = col.row()
-        row.enabled = is_enabled
-        row.label(text='Export Top Level Excluded Collections:')
-        row.prop(self, "exluded_collections", text='')self.hidden_geo = scene_ass.hidden_geo
+            self.hidden_geo = scene_ass.hidden_geo
             self.exluded_collections = scene_ass.exluded_collections
             self.apply_modifiers = scene_ass.apply_modifiers
             self.triangulate_faces = scene_ass.triangulate_faces
@@ -542,6 +538,7 @@ class ExportASS(Operator, ExportHelper):
         row.enabled = is_enabled
         row.label(text='Export Top Level Excluded Collections:')
         row.prop(self, "exluded_collections", text='')
+
 
         box = layout.box()
         box.label(text="Scene Options:")

--- a/io_scene_halo/file_ass/__init__.py
+++ b/io_scene_halo/file_ass/__init__.py
@@ -107,6 +107,12 @@ class ASS_ScenePropertiesGroup(PropertyGroup):
         default = True,
         )
 
+    exluded_collections: BoolProperty(
+        name ="Export top level excluded collections",
+        description = "Whether or not we ignore collections that are excluded from the view layer",
+        default = True,
+        )
+
     folder_structure: BoolProperty(
         name ="Generate Asset Subdirectories",
         description = "Generate folder subdirectories for exported assets",
@@ -223,6 +229,9 @@ class ASS_SceneProps(Panel):
         row = col.row()
         row.label(text='Export Hidden Geometry:')
         row.prop(scene_ass, "hidden_geo", text='')
+        row = col.row()
+        row.label(text='Export Excluded Top Level Collections:')
+        row.prop(scene_ass, "exluded_collections", text='')
 
         box = layout.box()
         box.label(text="Scene Options:")
@@ -325,6 +334,12 @@ class ExportASS(Operator, ExportHelper):
         default = True,
         )
 
+        exluded_collections: BoolProperty(
+        name ="Export excluded top level collections",
+        description = "Whether or not we ignore collections that are excluded from the view layer",
+        default = True,
+        )
+
     folder_structure: BoolProperty(
         name ="Generate Asset Subdirectories",
         description = "Generate folder subdirectories for exported assets",
@@ -415,6 +430,7 @@ class ExportASS(Operator, ExportHelper):
             parser.add_argument('-arg3', '--game_version', dest='game_version', type=str, default="halo2")
             parser.add_argument('-arg4', '--folder_structure', dest='folder_structure', action='store_true')
             parser.add_argument('-arg5', '--hidden_geo', dest='hidden_geo', action='store_true')
+            parser.add_argument('-arg5', '--exluded_collections', dest='exluded_collections', action='store_true')
             parser.add_argument('-arg6', '--apply_modifiers', dest='apply_modifiers', action='store_true')
             parser.add_argument('-arg7', '--triangulate_faces', dest='triangulate_faces', action='store_true')
             parser.add_argument('-arg8', '--clean_normalize_weights', dest='clean_normalize_weights', action='store_true')
@@ -431,6 +447,7 @@ class ExportASS(Operator, ExportHelper):
             print('game_version: ', args.game_version)
             print('folder_structure: ', args.folder_structure)
             print('hidden_geo: ', args.hidden_geo)
+            print('exluded_collections : ', args.exluded_collections)
             print('apply_modifiers: ', args.apply_modifiers)
             print('triangulate_faces: ', args.triangulate_faces)
             print('clean_normalize_weights: ', args.clean_normalize_weights)
@@ -446,6 +463,7 @@ class ExportASS(Operator, ExportHelper):
             self.game_version = args.game_version
             self.folder_structure = args.folder_structure
             self.hidden_geo = args.hidden_geo
+            self.exluded_collections = args.exluded_collections
             self.apply_modifiers = args.apply_modifiers
             self.triangulate_faces = args.triangulate_faces
             self.clean_normalize_weights = args.clean_normalize_weights
@@ -457,7 +475,7 @@ class ExportASS(Operator, ExportHelper):
             self.scale_float = args.scale_float
             self.console = args.console
 
-        return global_functions.run_code("export_ass.write_file(context, self.filepath, self.ass_version, self.ass_version_h2, self.ass_version_h3, self.game_version, self.folder_structure, self.hidden_geo, self.apply_modifiers, self.triangulate_faces, self.edge_split, self.use_edge_angle, self.use_edge_sharp, self.split_angle, self.clean_normalize_weights, self.scale_enum, self.scale_float, self.console, self.report)")
+        return global_functions.run_code("export_ass.write_file(context, self.filepath, self.ass_version, self.ass_version_h2, self.ass_version_h3, self.game_version, self.folder_structure, self.hidden_geo, exluded_collections, self.apply_modifiers, self.triangulate_faces, self.edge_split, self.use_edge_angle, self.use_edge_sharp, self.split_angle, self.clean_normalize_weights, self.scale_enum, self.scale_float, self.console, self.report)")
 
     def draw(self, context):
         scene = context.scene
@@ -474,7 +492,12 @@ class ExportASS(Operator, ExportHelper):
             self.ass_version_h2 = scene_ass.ass_version_h2
             self.ass_version_h3 = scene_ass.ass_version_h3
             self.folder_structure = scene_ass.folder_structure
-            self.hidden_geo = scene_ass.hidden_geo
+      
+row = col.row()
+        row.enabled = is_enabled
+        row.label(text='Export Top Level Excluded Collections:')
+        row.prop(self, "exluded_collections", text='')self.hidden_geo = scene_ass.hidden_geo
+            self.exluded_collections = scene_ass.exluded_collections
             self.apply_modifiers = scene_ass.apply_modifiers
             self.triangulate_faces = scene_ass.triangulate_faces
             self.clean_normalize_weights = scene_ass.clean_normalize_weights
@@ -515,6 +538,10 @@ class ExportASS(Operator, ExportHelper):
         row.enabled = is_enabled
         row.label(text='Export Hidden Geometry:')
         row.prop(self, "hidden_geo", text='')
+        row = col.row()
+        row.enabled = is_enabled
+        row.label(text='Export Top Level Excluded Collections:')
+        row.prop(self, "exluded_collections", text='')
 
         box = layout.box()
         box.label(text="Scene Options:")

--- a/io_scene_halo/file_ass/__init__.py
+++ b/io_scene_halo/file_ass/__init__.py
@@ -493,7 +493,7 @@ class ExportASS(Operator, ExportHelper):
             self.ass_version_h3 = scene_ass.ass_version_h3
             self.folder_structure = scene_ass.folder_structure
       
-row = col.row()
+        row = col.row()
         row.enabled = is_enabled
         row.label(text='Export Top Level Excluded Collections:')
         row.prop(self, "exluded_collections", text='')self.hidden_geo = scene_ass.hidden_geo

--- a/io_scene_halo/file_ass/build_asset.py
+++ b/io_scene_halo/file_ass/build_asset.py
@@ -32,8 +32,8 @@ from getpass import getuser
 from .process_scene import process_scene
 from ..global_functions import global_functions
 
-def build_asset(context, filepath, version, game_version, folder_structure, hidden_geo, apply_modifiers, triangulate_faces, edge_split, clean_normalize_weights, custom_scale, report):
-    ASS = process_scene(context, version, game_version, hidden_geo, apply_modifiers, triangulate_faces, edge_split, clean_normalize_weights, custom_scale, report)
+def build_asset(context, filepath, version, game_version, folder_structure, hidden_geo, exluded_collections, apply_modifiers, triangulate_faces, edge_split, clean_normalize_weights, custom_scale, report):
+    ASS = process_scene(context, version, game_version, hidden_geo, exluded_collections, apply_modifiers, triangulate_faces, edge_split, clean_normalize_weights, custom_scale, report)
 
     filename = os.path.basename(filepath)
     root_directory = global_functions.get_directory(context, game_version, "render", folder_structure, "0", False, filepath)

--- a/io_scene_halo/file_ass/export_ass.py
+++ b/io_scene_halo/file_ass/export_ass.py
@@ -29,13 +29,13 @@ import bpy
 from .build_asset import build_asset
 from ..global_functions import global_functions
 
-def write_file(context, filepath, ass_version, ass_version_h2, ass_version_h3, game_version, folder_structure, hidden_geo, apply_modifiers, triangulate_faces, edge_split, use_edge_angle, use_edge_sharp, split_angle, clean_normalize_weights, scale_enum, scale_float, console, report):
+def write_file(context, filepath, ass_version, ass_version_h2, ass_version_h3, game_version, folder_structure, hidden_geo, exluded_collections, apply_modifiers, triangulate_faces, edge_split, use_edge_angle, use_edge_sharp, split_angle, clean_normalize_weights, scale_enum, scale_float, console, report):
     custom_scale = global_functions.set_scale(scale_enum, scale_float)
     version = global_functions.get_version(ass_version, None, ass_version_h2, ass_version_h3, game_version, console)
 
     edge_split = global_functions.EdgeSplit(edge_split, use_edge_angle, split_angle, use_edge_sharp)
 
-    build_asset(context, filepath, version, game_version, folder_structure, hidden_geo, apply_modifiers, triangulate_faces, edge_split, clean_normalize_weights, custom_scale, report)
+    build_asset(context, filepath, version, game_version, folder_structure, hidden_geo, exluded_collections, apply_modifiers, triangulate_faces, edge_split, clean_normalize_weights, custom_scale, report)
 
     report({'INFO'}, "Export completed successfully")
     return {'FINISHED'}

--- a/io_scene_halo/file_ass/process_scene.py
+++ b/io_scene_halo/file_ass/process_scene.py
@@ -114,7 +114,7 @@ def scale_is_uniform(obj):
 
     return is_uniform
 
-    def process_scene(context, version, game_version, hidden_geo, exluded_collections, apply_modifiers, triangulate_faces, edge_split, clean_normalize_weights, custom_scale, report):
+def process_scene(context, version, game_version, hidden_geo, exluded_collections, apply_modifiers, triangulate_faces, edge_split, clean_normalize_weights, custom_scale, report):
     ASS = ASSAsset()
     
     if exluded_collections:

--- a/io_scene_halo/file_ass/process_scene.py
+++ b/io_scene_halo/file_ass/process_scene.py
@@ -114,7 +114,7 @@ def scale_is_uniform(obj):
 
     return is_uniform
 
-    def process_scene(context, version, game_version, hidden_geo, exluded_collections:, apply_modifiers, triangulate_faces, edge_split, clean_normalize_weights, custom_scale, report):
+    def process_scene(context, version, game_version, hidden_geo, exluded_collections, apply_modifiers, triangulate_faces, edge_split, clean_normalize_weights, custom_scale, report):
     ASS = ASSAsset()
     
     if exluded_collections:

--- a/io_scene_halo/file_ass/process_scene.py
+++ b/io_scene_halo/file_ass/process_scene.py
@@ -114,10 +114,13 @@ def scale_is_uniform(obj):
 
     return is_uniform
 
-def process_scene(context, version, game_version, hidden_geo, exluded_collections, apply_modifiers, triangulate_faces, edge_split, clean_normalize_weights, custom_scale, report):
+    def process_scene(context, version, game_version, hidden_geo, exluded_collections:, apply_modifiers, triangulate_faces, edge_split, clean_normalize_weights, custom_scale, report):
     ASS = ASSAsset()
-
-    global_functions.unhide_all_collections(context)
+    
+    if exluded_collections:
+        global_functions.unhide_all_collections(context)
+    elif not exluded_collections:
+        global_functions.only_unhide_all_collections(context)
 
     default_region = mesh_processing.get_default_region_permutation_name(game_version)
     default_permutation = mesh_processing.get_default_region_permutation_name(game_version)

--- a/io_scene_halo/file_ass/process_scene.py
+++ b/io_scene_halo/file_ass/process_scene.py
@@ -114,7 +114,7 @@ def scale_is_uniform(obj):
 
     return is_uniform
 
-def process_scene(context, version, game_version, hidden_geo, apply_modifiers, triangulate_faces, edge_split, clean_normalize_weights, custom_scale, report):
+def process_scene(context, version, game_version, hidden_geo, exluded_collections, apply_modifiers, triangulate_faces, edge_split, clean_normalize_weights, custom_scale, report):
     ASS = ASSAsset()
 
     global_functions.unhide_all_collections(context)
@@ -127,7 +127,27 @@ def process_scene(context, version, game_version, hidden_geo, apply_modifiers, t
     region_list = []
     permutation_list = []
 
-    object_list = list(context.scene.objects)
+    object_list = []
+    
+    #Ignore excluded top level collections if the option is disabled in Mask Options
+    #Causes error if any child object is in an enabled layer, and its parent object is in a disabled layer
+    if not exluded_collections:
+        export_collection_list = []
+        scene_collection = bpy.context.view_layer.layer_collection
+        top_collections = scene_collection.children
+        for collection in top_collections:
+            if not collection.exclude:
+                export_collection_list.append(collection)
+        
+        for obj in scene_collection.collection.objects:
+                object_list.append(obj)
+        
+        for collection in export_collection_list:
+            for obj in collection.collection.all_objects:
+                object_list.append(obj)
+    #Include all objects if the exclude top level collections option is eneabled in Mask Options
+    else:
+        object_list = list(context.scene.objects)
 
     ASS.materials = []
     ASS.objects = []

--- a/io_scene_halo/global_functions/global_functions.py
+++ b/io_scene_halo/global_functions/global_functions.py
@@ -120,8 +120,10 @@ class ParentIDFix():
         self.clavicle1 = clavicle1
 
 def unhide_all_collections(context):
-    for collection_viewport in context.view_layer.layer_collection.children:
-        collection_viewport.exclude = False
+    #Needs to re-exclude exlcuded collections if excluded collections are exported
+    if exluded_collections:
+        for collection_viewport in context.view_layer.layer_collection.children:
+            collection_viewport.exclude = False
 
     for collection_hide in bpy.data.collections:
         collection_hide.hide_viewport = False

--- a/io_scene_halo/global_functions/global_functions.py
+++ b/io_scene_halo/global_functions/global_functions.py
@@ -120,12 +120,8 @@ class ParentIDFix():
         self.clavicle1 = clavicle1
 
 def unhide_all_collections(context):
-    #Needs to re-exclude exlcuded collections if excluded collections are exported
-    if exluded_collections is None:
-        for collection_viewport in context.view_layer.layer_collection.children:
-            collection_viewport.exclude = False
-    elif exluded_collections:
-        pass
+    for collection_viewport in context.view_layer.layer_collection.children:
+        collection_viewport.exclude = False
 
     for collection_hide in bpy.data.collections:
         collection_hide.hide_viewport = False

--- a/io_scene_halo/global_functions/global_functions.py
+++ b/io_scene_halo/global_functions/global_functions.py
@@ -126,6 +126,11 @@ def unhide_all_collections(context):
     for collection_hide in bpy.data.collections:
         collection_hide.hide_viewport = False
 
+#Only unhides all collections
+def only_unhide_all_collections(context):
+    for collection_hide in bpy.data.collections:
+        collection_hide.hide_viewport = False
+
 def get_child(bone, bone_list):
     set_node = None
     for node in bone_list:

--- a/io_scene_halo/global_functions/global_functions.py
+++ b/io_scene_halo/global_functions/global_functions.py
@@ -121,9 +121,11 @@ class ParentIDFix():
 
 def unhide_all_collections(context):
     #Needs to re-exclude exlcuded collections if excluded collections are exported
-    if exluded_collections:
+    if exluded_collections is None:
         for collection_viewport in context.view_layer.layer_collection.children:
             collection_viewport.exclude = False
+    elif exluded_collections:
+        pass
 
     for collection_hide in bpy.data.collections:
         collection_hide.hide_viewport = False


### PR DESCRIPTION
Added boolean option to ignore top level collections that are excluded from the view layer for ASS exports. Will cause error if any child object is in an enabled layer, and its parent object is in a disabled layer. Will operate as previously if enabled (by default).