### PR TITLE
Ignore node prefixes when getting pose bones during JMA imports

### DIFF
--- a/io_scene_halo/file_jma/build_scene.py
+++ b/io_scene_halo/file_jma/build_scene.py
@@ -289,6 +289,11 @@ def find_valid_armature(context, JMA, obj):
 
     return scene_nodes, valid_armature
 
+def get_pose_bone(arm: bpy.types.Object, node_name: str) -> bpy.types.PoseBone | None:
+    for bone in arm.pose.bones:
+        if remove_node_prefix(bone.name).lower() == node_name.lower():
+            return bone
+
 def build_scene(context, JMA, JMS_A, JMS_B, filepath, game_version, fix_parents, fix_rotations, report):
     collection = context.collection
     scene = context.scene
@@ -399,7 +404,7 @@ def build_scene(context, JMA, JMS_A, JMS_B, filepath, game_version, fix_parents,
             armature.keyframe_insert('rotation_euler')
 
         for idx, node in enumerate(nodes):
-            pose_bone = armature.pose.bones.get(node.name)
+            pose_bone = get_pose_bone(armature, node.name)
             if not pose_bone == None:
                 matrix_scale = Matrix.Scale(frame[idx].scale, 4)
                 matrix_rotation = frame[idx].rotation.to_matrix().to_4x4()

--- a/io_scene_halo/file_jma/build_scene.py
+++ b/io_scene_halo/file_jma/build_scene.py
@@ -290,6 +290,12 @@ def find_valid_armature(context, JMA, obj):
     return scene_nodes, valid_armature
 
 def get_pose_bone(arm: bpy.types.Object, node_name: str) -> bpy.types.PoseBone | None:
+    # Check for exact matches first
+    for bone in arm.pose.bones:
+        if bone.name.lower() == node_name.lower():
+            return bone
+    
+    # If a bone hasn't been found yet, test whether the node name matches a bone name stripped of prefixes
     for bone in arm.pose.bones:
         if remove_node_prefix(bone.name).lower() == node_name.lower():
             return bone
@@ -404,7 +410,7 @@ def build_scene(context, JMA, JMS_A, JMS_B, filepath, game_version, fix_parents,
             armature.keyframe_insert('rotation_euler')
 
         for idx, node in enumerate(nodes):
-            pose_bone = get_pose_bone(armature, node.name)
+            pose_bone = armature.pose.bones.get(node.name)
             if not pose_bone == None:
                 matrix_scale = Matrix.Scale(frame[idx].scale, 4)
                 matrix_rotation = frame[idx].rotation.to_matrix().to_4x4()

--- a/io_scene_halo/file_jma/build_scene.py
+++ b/io_scene_halo/file_jma/build_scene.py
@@ -410,7 +410,7 @@ def build_scene(context, JMA, JMS_A, JMS_B, filepath, game_version, fix_parents,
             armature.keyframe_insert('rotation_euler')
 
         for idx, node in enumerate(nodes):
-            pose_bone = armature.pose.bones.get(node.name)
+            pose_bone = get_pose_bone(armature, node.name)
             if not pose_bone == None:
                 matrix_scale = Matrix.Scale(frame[idx].scale, 4)
                 matrix_rotation = frame[idx].rotation.to_matrix().to_4x4()


### PR DESCRIPTION
Small change to the logic for when a pose bone is grabbed and given keyframes during JMA imports. Instead pose.bones.get(), the bone names themselves are first compared directly to JMA node names (so that exact matches are prioritised), and then the bone names are stripped of prefixes and checked against node names.

The benefit of this is allowing JMA imports over JMS imported armatures that retain their node prefixes.