### PR TITLE
Add description info for material emissive_focus option

### DIFF
--- a/io_scene_halo/global_ui/material_ui.py
+++ b/io_scene_halo/global_ui/material_ui.py
@@ -684,9 +684,9 @@ class ASS_JMS_MaterialPropertiesGroup(PropertyGroup):
 
     emissive_focus: FloatProperty(
         name = "Emissive Focus",
-        description = "I have no idea what this is",
+        description = "Controls the angle/FOV of emitted light. At 0.0, light radiates 180° from the surface normal, but may leak to surrounding geometry; at 1.0, it's focused forward within a 120° arc from the surface normal. Each value increase of 0.5 is a decrease of 30°. Caps at 1.5 (90°)",
         default = 0.0,
-        max = 1.0,
+        max = 1.5,
         min = 0.0,
         )
 


### PR DESCRIPTION
Stumbled upon what this value actually does when doing some testing trying to get emissive material lighting in H3 to act more like it did in H2.

Did extensive testing to determine the relationship between value and angle, see the images below. This is a small box bsp with a lightmap plane in the exact center, with the face normal pointing downwards. Light power is 20, only value that was changed was the emissive focus. Lit on direct-only to avoid bounce lighting making angles more difficult to determine

0.0 (180°):
![image](https://github.com/user-attachments/assets/61d177c3-73ac-46bd-ae4a-2f0e1be2dc75)

0.5 (150°):
![image](https://github.com/user-attachments/assets/95c8c6ce-8e41-425d-a367-dccd36563d05)

1.0 (120°):
![image](https://github.com/user-attachments/assets/212abcd7-4c83-4013-93d9-b8c7f674295e)

1.5 (90°):
![image](https://github.com/user-attachments/assets/287a0359-7b9b-40fa-a735-529d206b8b98)

