### PR TITLE
Fix for vertex groups weight normalization on export

### DIFF
--- a/io_scene_halo/global_functions/mesh_processing.py
+++ b/io_scene_halo/global_functions/mesh_processing.py
@@ -327,7 +327,7 @@ def vertex_group_clean_normalize(context, obj, limit_value):
         bpy.ops.mesh.select_all(action='SELECT')
         bpy.ops.object.vertex_group_clean(group_select_mode='ALL', limit=limit_value)
         bpy.ops.object.vertex_group_limit_total(group_select_mode='ALL', limit=4)
-        bpy.ops.object.vertex_group_normalize_all(group_select_mode='ALL')
+        bpy.ops.object.vertex_group_normalize_all(group_select_mode='ALL', lock_active=False)
         bpy.ops.object.mode_set(mode = 'OBJECT')
 
         context.view_layer.update()


### PR DESCRIPTION
Fixes the normalization from locking down an active vertex group leading to improper weights in some cases